### PR TITLE
Nft contract as owner bug

### DIFF
--- a/test/ERC721X.test.js
+++ b/test/ERC721X.test.js
@@ -98,6 +98,15 @@ contract('Card', accounts => {
         supplyPostMint.should.be.eq.BN(supplyPostSecondMint)
     })
 
+    it('Should be impossible to mint NFT tokens more than once even when owner is the contract itself', async () => {
+        const uid = 0;
+        await card.mint(uid, card.address);
+        const supplyPostMint = await card.totalSupply()
+        await expectThrow(card.mint(uid, card.address, 3))
+        const supplyPostSecondMint = await card.totalSupply()
+        supplyPostMint.should.be.eq.BN(supplyPostSecondMint)
+    })
+
     it('Should be able to transfer a non fungible token', async () => {
         const uid = 0
         await card.mint(uid, alice)


### PR DESCRIPTION
Using the contract as owner might not be a good idea after all, at least unless we can also block the contract from owning NFT.

