### PR TITLE
Fix batch transfer NFT bug

### DIFF
--- a/contracts/Core/ERC721X/ERC721XToken.sol
+++ b/contracts/Core/ERC721X/ERC721XToken.sol
@@ -48,6 +48,10 @@ contract ERC721XToken is ERC721X, ERC721XTokenNFT {
         require(_tokenIds.length == _amounts.length, "Inconsistent array length between args");
         require(_to != address(0), "Invalid recipient");
 
+        if (tokenType[_tokenIds[0]] == NFT) {
+            tokenOwner[_tokenIds[0]] = _to;
+        }
+
         // Load first bin and index where the object balance exists
         (uint256 bin, uint256 index) = ObjectLib.getTokenBinIndex(_tokenIds[0]);
 
@@ -67,6 +71,10 @@ contract ERC721XToken is ERC721X, ERC721XTokenNFT {
         uint256 lastBin = bin;
 
         for (uint256 i = 1; i < nTransfer; i++) {
+            // If we're transferring an NFT we additionally should update the tokenOwner
+            if (tokenType[_tokenIds[i]] == NFT) {
+                tokenOwner[_tokenIds[i]] = _to;
+            }
             (bin, index) = _tokenIds[i].getTokenBinIndex();
 
             // If new bin

--- a/test/ERC721X.test.js
+++ b/test/ERC721X.test.js
@@ -194,6 +194,40 @@ contract('Card', accounts => {
         await expectThrow(card.mint(alice, 0, 150000));
     })
 
+    it('Should update balances of sender and receiver and ownerOf for NFTs', async () => {
+        //       bins :   -- 0 --  ---- 1 ----  ---- 2 ----  ---- 3 ----
+        let cards  = []; //[0,1,2,3, 16,17,18,19, 32,33,34,35, 48,49,50,51];
+        let copies = []; //[0,1,2,3, 12,13,14,15, 11,12,13,14, 11,12,13,14];
+
+        let nCards = 100;
+
+        //Minting enough copies for transfer for each cards
+        for (let i = 300; i < nCards + 300; i++){
+            await card.mint(i, alice);
+            cards.push(i);
+            copies.push(1);
+        }
+
+        const tx = await card.batchTransferFrom(alice, bob, cards, copies, {from: alice});
+
+        let balanceFrom;
+        let balanceTo;
+        let ownerOf;
+
+        for (let i = 0; i < cards.length; i++){
+            balanceFrom = await card.balanceOf(alice, cards[i]);
+            balanceTo   = await card.balanceOf(bob, cards[i]);
+            ownerOf = await card.ownerOf(cards[i]);
+
+            balanceFrom.should.be.eq.BN(0);
+            balanceTo.should.be.eq.BN(1);
+            assert.equal(ownerOf, bob);
+        }
+
+        assertEventVar(tx, 'BatchTransfer', 'from', alice)
+        assertEventVar(tx, 'BatchTransfer', 'to', bob)
+    })
+
     it('Should update balances of sender and receiver', async () => {
         //       bins :   -- 0 --  ---- 1 ----  ---- 2 ----  ---- 3 ----
         let cards  = []; //[0,1,2,3, 16,17,18,19, 32,33,34,35, 48,49,50,51];


### PR DESCRIPTION
As @PhABC correctly points out in https://www.reddit.com/r/ethdev/comments/9frmcn/here_be_dragons_going_beyond_erc20_and_erc721_to/

> I don't understand why tokenOwner is updated when calling the _transferFrom method, but not when calling _batchTransferFrom(). I believe this means that batch transfer will lead to incompatible outcome with ERC-721, since transferring tokens with _batchTransferFrom() does not change the tokenOwner mapping, which indicates who owns which token.

PR addresses this by updating `tokenOwner` if `tokenType[_tokenIds[i]] == NFT`